### PR TITLE
[ Fix Markers on Map ]

### DIFF
--- a/lib/components/widgets/location_input.dart
+++ b/lib/components/widgets/location_input.dart
@@ -33,33 +33,32 @@ class _LocationInputState extends State<LocationInput> {
   }
 
   Future<void> _savePlace(double latitude, double longitude) async {
-  final url = Uri.parse(
-    'https://maps.googleapis.com/maps/api/geocode/json?latlng=$latitude,$longitude&key=$apiKey',
-  );
-  final response = await http.get(url);
-  final resData = json.decode(response.body);
+    final url = Uri.parse(
+      'https://maps.googleapis.com/maps/api/geocode/json?latlng=$latitude,$longitude&key=$apiKey',
+    );
+    final response = await http.get(url);
+    final resData = json.decode(response.body);
 
-  if (resData['results'] != null && resData['results'].isNotEmpty) {
-    final locationDetail = resData['results'][0]['formatted_address'];
+    if (resData['results'] != null && resData['results'].isNotEmpty) {
+      final locationDetail = resData['results'][0]['formatted_address'];
 
-    setState(() {
-      _pickedLocation = PlaceLocation(
-        latitude: latitude,
-        longitude: longitude,
-        locationDetail: locationDetail,
-      );
-      _isGettingLocation = false;
-    });
+      setState(() {
+        _pickedLocation = PlaceLocation(
+          latitude: latitude,
+          longitude: longitude,
+          locationDetail: locationDetail,
+        );
+        _isGettingLocation = false;
+      });
 
-    widget.onSelectLocation(_pickedLocation!);
-  } else {
-    setState(() {
-      _isGettingLocation = false;
-    });
-    print('No location details found');
+      widget.onSelectLocation(_pickedLocation!);
+    } else {
+      setState(() {
+        _isGettingLocation = false;
+      });
+      print('No location details found');
+    }
   }
-}
-
 
   void _getCurrentLocation() async {
     Location location = Location();

--- a/lib/pages/map.dart
+++ b/lib/pages/map.dart
@@ -54,7 +54,10 @@ class _MapScreenState extends State<MapScreen> {
     List<Marker> markers = [];
 
     // Markers for user's current location
-    if (_pickedLocation != null && widget.isSelecting) {
+    if (_pickedLocation != null &&
+        !widget.isSelecting &&
+        widget.foundItems == null &&
+        widget.lostItems == null) {
       markers.add(
         Marker(
           markerId: const MarkerId('user_location'),
@@ -67,7 +70,7 @@ class _MapScreenState extends State<MapScreen> {
     }
 
     // Markers for found items
-    if (widget.foundItems != null) {
+    if (widget.foundItems != null && !widget.isSelecting) {
       for (var foundItem in widget.foundItems!) {
         markers.add(
           Marker(
@@ -93,7 +96,7 @@ class _MapScreenState extends State<MapScreen> {
     }
 
     // Markers for lost items
-    if (widget.lostItems != null) {
+    if (widget.lostItems != null && !widget.isSelecting) {
       for (var lostItem in widget.lostItems!) {
         markers.add(
           Marker(
@@ -118,10 +121,6 @@ class _MapScreenState extends State<MapScreen> {
           ),
         );
       }
-    }
-
-    if (markers.isNotEmpty) {
-      _markers.add(markers.first);
     }
 
     _markers.addAll(markers);
@@ -153,6 +152,15 @@ class _MapScreenState extends State<MapScreen> {
                   _pickedLocation = position;
                   _updateMarkers();
                 });
+                _markers.add(
+                  Marker(
+                    markerId: const MarkerId('selected_location'),
+                    position: position,
+                    icon: BitmapDescriptor.defaultMarkerWithHue(
+                      BitmapDescriptor.hueRed,
+                    ),
+                  ),
+                );
               },
         initialCameraPosition: CameraPosition(
           target: LatLng(
@@ -161,7 +169,32 @@ class _MapScreenState extends State<MapScreen> {
           ),
           zoom: 16,
         ),
-        markers: _markers,
+        markers: (_pickedLocation != null && !widget.isSelecting)
+            ? {
+                Marker(
+                  markerId: const MarkerId('user_location'),
+                  position: _pickedLocation!,
+                  icon: BitmapDescriptor.defaultMarkerWithHue(
+                    BitmapDescriptor.hueRed,
+                  ),
+                ),
+                ..._markers,
+              }
+            : (_pickedLocation == null && !widget.isSelecting)
+                ? {
+                    Marker(
+                      markerId: const MarkerId('user_location'),
+                      position: LatLng(
+                        widget.location.latitude,
+                        widget.location.longitude,
+                      ),
+                      icon: BitmapDescriptor.defaultMarkerWithHue(
+                        BitmapDescriptor.hueRed,
+                      ),
+                    ),
+                    ..._markers, // Add all the existing markers
+                  }
+                : Set<Marker>.from(_markers),
       ),
     );
   }


### PR DESCRIPTION
- Display markers if foundItems and lostItems exist
- Display one red marker if opening the map through the detail screen or anywhere where the user did not selecting a location and the location is not empty
- Allow user to tap on the map if user is selecting a location and then assign a red marker in the tapped location

Markers if foundItems and lostItems exist:
![image](https://github.com/fin-it/finit-frontend/assets/90896452/014269f6-0875-4457-bc20-d0066f5cd1d7)

Markers if foundItems and lostItems are null but the picked location is not null and user is not selecting a location:
![image](https://github.com/fin-it/finit-frontend/assets/90896452/f156d0f8-08e8-42fb-8f42-a38bf5df46ed)

Markers if user is not yet selecting a location:
![image](https://github.com/fin-it/finit-frontend/assets/90896452/14a29067-2c09-4773-8ae1-ff60055f0ffc)

Markers when user tapped to select a location:
![image](https://github.com/fin-it/finit-frontend/assets/90896452/16fa0a92-f8f3-4e63-9a4e-900ed28e3724)
